### PR TITLE
fix: Issue with callbacks

### DIFF
--- a/SCMerchantClient/SCMerchantClient.php
+++ b/SCMerchantClient/SCMerchantClient.php
@@ -133,7 +133,7 @@ class SCMerchantClient
 
 		if ($c != null) {
 
-			if ($this->userId != $c->getUserId() || $this->merchantApiId != $c->getMerchantApiId())
+			if ($this->merchantId != $c->getUserId() || $this->apiId != $c->getMerchantApiId())
 				return $valid;
 
 			if (!$c->validate())

--- a/SCMerchantClient/data/OrderCallback.php
+++ b/SCMerchantClient/data/OrderCallback.php
@@ -23,8 +23,8 @@ class OrderCallback
 
 	function __construct($userId, $merchantApiId, $merchantId, $apiId, $orderId, $payCurrency, $payAmount, $receiveCurrency, $receiveAmount, $receivedAmount, $description, $orderRequestId, $status, $sign, $payerName, $payerSurname, $payerEmail)
 	{
-		$this->$userId = $userId;
-		$this->$merchantApiId = $merchantApiId;
+		$this->userId = $userId;
+		$this->merchantApiId = $merchantApiId;
 		$this->merchantId = $merchantId;
 		$this->apiId = $apiId;
 		$this->orderId = $orderId;


### PR DESCRIPTION
I have been integrating this library in a project and I have discovered some bugs in the code.

- Inside `OrderCallback.php`, in the constructor it has an error in the assignment of the variable `userId` and `merchantApiId` which failed to assign values to these.

BEFORE:
```
$this->$userId = $userId;
$this->$merchantApiId = $merchantApiId;
```
AFTER:
```
$this->userId = $userId;
$this->merchantApiId = $merchantApiId;
```

- The other error is in the function `validateCreateOrderCallback` from `SCMerchantClient.php`, there the system was trying to compare the userId from callback with a not exist `$this->userId` var. 